### PR TITLE
Support for automatic logins if token gets invalidated

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Referencing objects via it's objectname is not yet implemented.
 
 Oscar Mattsson  
 
+David Ygland
+
 ## License
 
 [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/integrated_tokenhandler.md
+++ b/integrated_tokenhandler.md
@@ -1,33 +1,40 @@
 # Integrating token handler with ansible.
 
-To avoid having to consistently check for valid storedsafe token, this can be integrated directly into ansible via a pre_task.
+To avoid having to consistently check for valid storedsafe token, this can be integrated directly into handler using a tokenhandler login script 
 
-## ansible pre task example
+## wrapper.sh 
 
-In a playbook that requires a valid token, or site.yml, add the following:
+Create a simple script that utilizes tokenhandler to check for valid token, and log in if none is found
 
-```
-- hosts: all
-  gather_facts: True
-  pre_tasks:
-    - name: obtain storedsafe toke
-  ansible.builtin.command:
-    cmd: ../../tokenhandler/wrapper.sh
-  delegate_to: localhost
-  become: no
-  run_once: true
-```
-run_once is necessary to only call login once. 
-wrapper.sh is just a simple wrapper:
+For example:
 
 ```
-#!/usr/bin/bash
-# relative to ansible/playbooks/
-TOKENHANDLER=../../tokenhandler/tookenhandler.py 
-${TOKENHANDLER} check > /dev/null
-if [ $? -eq 1 ]; then
-  ${TOKENHANDLER} login
+#!/bin/env bash
+
+TOKENHANDLER_PATH=$(find /home/ -name "tokenhandler.py" 2>/dev/null | head -n1)
+TOKENHANDLER="python3 $TOKENHANDLER_PATH"
+if [ -f $TOKENHANDLER_PATH ]; then
+  ${TOKENHANDLER} check > /dev/null
+  if [ $? -eq 1 ]; then
+    ${TOKENHANDLER} login
+  else
+    exit 0
+  fi
 else
-  exit 0
+  echo "No tokenhandler found"
+  exit 1
 fi
+
 ```
+
+## Usage
+Add the location of the wrapper.sh script to either environment variables using `STOREDSAFE_TOKEN_UPDATE_SCRIPT` or as an ansible var using `storedsafe_token_update_script`
+
+`export STOREDSAFE_TOKEN_UPDATE_SCRIPT="/home/$USER/git/tools/wrapper.sh"`
+(This is of course inserted in to your .bashrc or similar start-up script)
+
+or, in any relevant group_vars:
+
+`storedsafe_token_update_script: /home/$USER/git/tools/wrapper.sh`
+(Note: unqouted)
+


### PR DESCRIPTION
This PR adds capability to add a optional script for plugin to use as wrapper around tokenhandler. If user has supplied the script path via vars or env the script will run under certain conditions:
* Not logged in to storedsage
* Invalid token (i.e. error 403 from StoredSafe)
The plugin will retry to login 5 times and therafter raise an exception.

If user has not supplied any path to script the functionality is unchanged

